### PR TITLE
fix: error when no options are provided

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ class PDFExtract {
 	constructor() {
 	}
 
-	extract(filename, options, cb) {
+	extract(filename, options = {}, cb) {
 		if (!cb) {
 			return new Promise((resolve, reject) => {
 				this.extract(filename, options, (err, data) => {


### PR DESCRIPTION
When using `pdfExtract.extract(file)` with no `options` object, the following error occurs:

```js
if (options.verbosity === undefined) {
                            ^

TypeError: Cannot read property 'verbosity' of undefined
```

This fix sets `options` to `{}` by default.