### PR TITLE
don't clobber global.document if it already exists

### DIFF
--- a/lib/pdfjs/domstubs.js
+++ b/lib/pdfjs/domstubs.js
@@ -261,15 +261,19 @@ exports.document = document;
 exports.Image = Image;
 
 const exported_symbols = Object.keys(exports);
+const stubbed_symbols = [];
 
 exports.setStubs = function (namespace) {
 	exported_symbols.forEach(function (key) {
-		console.assert(!(key in namespace), "property should not be set: " + key);
-		namespace[key] = exports[key];
+		// don't clobber existing properties
+		if (!key in namespace) {
+			namespace[key] = exports[key];
+			stubbed_symbols.push(key);
+		}
 	});
 };
 exports.unsetStubs = function (namespace) {
-	exported_symbols.forEach(function (key) {
+	stubbed_symbols.forEach(function (key) {
 		console.assert(key in namespace, "property should be set: " + key);
 		delete namespace[key];
 	});


### PR DESCRIPTION
In my project, the global namespace is already populated with a functional JSDOM `document` implementation, and `setStubs` was replacing it with a non-functional stub.